### PR TITLE
Wrap Erlang API in Elixir

### DIFF
--- a/lib/open_telemetry.ex
+++ b/lib/open_telemetry.ex
@@ -1,4 +1,28 @@
 defmodule OpenTelemetry do
+  # Shortcuts that operate implicitly on the current Tracer
+  defdelegate start_span(name), to: :otel
+  defdelegate start_span(name, options), to: :otel
+  defdelegate with_span(span_ctx), to: :otel
+  defdelegate with_span(span_ctx, fun), to: :otel
+  defdelegate current_span_ctx(), to: :otel
+  defdelegate end_span(), to: :otel
+
+  # Manage the Tracer
+  defdelegate set_default_tracer(tracer), to: :opentelemetry
+  defdelegate get_tracer(), to: :opentelemetry
+  defdelegate get_tracer(name), to: :opentelemetry
+
+  # Helpers to build OpenTelemetry structured types
+  defdelegate timestamp(), to: :opentelemetry
+  defdelegate links(link_list), to: :opentelemetry
+  defdelegate link(trace_id, span_id, attributes, trace_state), to: :opentelemetry
+  defdelegate event(name, attributes), to: :opentelemetry
+  defdelegate timed_event(timestamp, name, attributes), to: :opentelemetry
+  defdelegate timed_event(timestamp, event), to: :opentelemetry
+  defdelegate timed_events(timed_event_list), to: :opentelemetry
+  defdelegate status(code, message), to: :opentelemetry
+
+  # Do these need to be in a public API?
   defdelegate generate_trace_id(), to: :opentelemetry
   defdelegate generate_span_id(), to: :opentelemetry
 end

--- a/lib/open_telemetry/span.ex
+++ b/lib/open_telemetry/span.ex
@@ -1,0 +1,13 @@
+defmodule OpenTelemetry.Span do
+  @moduledoc false
+
+  defdelegate start_span(tracer, span_name, options), to: :ot_span
+  defdelegate end_span(tracer, span_ctx), to: :ot_span
+  defdelegate get_ctx(tracer, span), to: :ot_span
+  defdelegate is_recording_events(tracer, span_ctx), to: :ot_span
+  defdelegate set_attribute(tracer, span_ctx, key, value), to: :ot_span
+  defdelegate set_attributes(tracer, span_ctx, attributes), to: :ot_span
+  defdelegate add_events(tracer, span_ctx, events), to: :ot_span
+  defdelegate set_status(tracer, span_ctx, status), to: :ot_span
+  defdelegate update_name(tracer, span_ctx, name), to: :ot_span
+ end

--- a/lib/open_telemetry/tracer.ex
+++ b/lib/open_telemetry/tracer.ex
@@ -1,0 +1,10 @@
+defmodule OpenTelemetry.Tracer do
+  @moduledoc false
+
+  defdelegate start_span(tracer, span_name, options), to: :ot_tracer
+  defdelegate with_span(tracer, span_ctx), to: :ot_tracer
+  defdelegate with_span(tracer, span_ctx, fun), to: :ot_tracer
+  defdelegate current_span_ctx(tracer), to: :ot_tracer
+  defdelegate get_binary_format(tracer), to: :ot_tracer
+  defdelegate get_http_text_format(tracer), to: :ot_tracer
+end

--- a/mix.exs
+++ b/mix.exs
@@ -5,7 +5,7 @@ defmodule OpenTelemetry.MixProject do
     [
       app: :open_telemetry,
       version: "0.1.0",
-      elixir: "~> 1.9",
+      elixir: "~> 1.8",
       start_permanent: Mix.env() == :prod,
       # We should never have dependencies
       deps: [],

--- a/test/open_telemetry_test.exs
+++ b/test/open_telemetry_test.exs
@@ -1,0 +1,19 @@
+defmodule OpenTelemetryTest do
+  use ExUnit.Case, async: true
+
+  test "current_span tracks nesting" do
+    _ctx1 = OpenTelemetry.start_span("span-1")
+    ctx2 = OpenTelemetry.start_span("span-2")
+
+    assert ctx2 == OpenTelemetry.current_span_ctx()
+  end
+
+  test "closing a span makes the parent current" do
+    ctx1 = OpenTelemetry.start_span("span-1")
+    ctx2 = OpenTelemetry.start_span("span-2")
+
+    assert ctx2 == OpenTelemetry.current_span_ctx()
+    OpenTelemetry.end_span()
+    assert ctx1 == OpenTelemetry.current_span_ctx()
+  end
+end

--- a/test/test_helper.exs
+++ b/test/test_helper.exs
@@ -1,0 +1,1 @@
+ExUnit.start()


### PR DESCRIPTION
Here's a naive wrapping of the Erlang API in Elixir, with a minimal re-implementation of a couple of the Erlang tests as a sanity check.

TODO:
- [ ]  figure out whether any of the wrapped functions need to convert between idiomatic Elixir types and Erlang.
- [ ] Documentation
- [ ] Type declarations